### PR TITLE
Issue - grainy bar at high speed

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,11 @@
                     <button id="button_reset">reset()</button>
                 </div>
             </div>
+            <div class="row">
+                <div class="pie_progress--slow" role="progressbar">
+                    <span class="pie_progress__number">0%</span>
+                </div>
+            </div>
         </section>
     </section>
 
@@ -70,6 +75,16 @@
         });
         $('#button_reset').on('click', function(){
             $('.pie_progress').asPieProgress('reset');
+        });
+
+        // Example with grater loading time - loads longer
+        $('.pie_progress--slow').asPieProgress({
+            'namespace': 'pie_progress',
+             goal: 1000,
+             min: 0,
+             max: 1000,
+             speed: 200,
+             easing: 'linear'
         });
     });
     </script>

--- a/src/jquery-asPieProgress.js
+++ b/src/jquery-asPieProgress.js
@@ -103,7 +103,7 @@
         fillcolor: 'none',
         easing: 'ease',
         numberCallback: function(n) {
-            var percentage = this.getPercentage(n);
+            var percentage = Math.round(this.getPercentage(n));
             return percentage + '%';
         },
         contentCallback: null
@@ -296,8 +296,9 @@
                 this.options[onFunction].apply(this, method_arguments);
             }
         },
+        // Return the percentage based on the current step
         getPercentage: function(n) {
-            return Math.round(100 * (n - this.min) / (this.max - this.min));
+            return 100 * (n - this.min) / (this.max - this.min);
         },
         go: function(goal) {
             var self = this;


### PR DESCRIPTION
When one set the speed to `>200` the bar bar's animation looks less smooth (grainy).

This pull request proposes a fix for this issue.